### PR TITLE
i.satskred: add areaname from output_dir

### DIFF
--- a/src/imagery/i.satskred/i.satskred.py
+++ b/src/imagery/i.satskred/i.satskred.py
@@ -300,7 +300,13 @@ def main():
         gs.call(
             ["satskred", "init"]
             + config_list
-            + ["--projname", "UTM33N", str(output_directory)]
+            + [
+                "--areaname",
+                output_directory.name,
+                "--projname",
+                "UTM33N",
+                str(output_directory),
+            ]
             + region_list
         )
 


### PR DESCRIPTION
Liten endring som bruker mappe-navn fra output-mappa som område navn.

Vi kan alternativt også ha område navn som eksplisitt input...