### PR TITLE
g.unzip: preserve modification time of unzipped files

### DIFF
--- a/src/general/g.unzip/testsuite/test_g_unzip.py
+++ b/src/general/g.unzip/testsuite/test_g_unzip.py
@@ -34,7 +34,22 @@ class TestGUnzipParallel(TestCase):
         """Remove the temporary data"""
         gs.utils.try_rmdir(cls.tempdir)
 
-    def test_g_unzip(self):
+    def test_g_unzip_no_out_dir(self):
+        """Test unzipping to output directory while
+        removing zip files in parallel"""
+        # Check that zip-files are created
+        self.assertTrue(len(list(self.tempdir.glob("testfile_*.zip"))) == 4)
+        # Check that g.unzip runs successfully
+        self.assertModule(
+            "g.unzip",
+            input=str(self.tempdir),
+            nprocs=2,
+            verbose=True,
+        )
+        # Check that unzipped-files exist in the file system
+        self.assertTrue(len(list((self.tempdir).glob("testfile_*.txt"))) == 4)
+
+    def test_g_unzip_with_out_dir(self):
         """Test unzipping to output directory while
         removing zip files in parallel"""
         # Check that zip-files are created


### PR DESCRIPTION
Unzipping i Python med `extractall` tar ikke vare på "timestamp" av filen i zip-arkiv. Denne PR jobber seg rund denne begrensningen. Riktig endringsdato trengs hvis vi ønsker å laste ned oppdaterte versjoner av scener etter hvert...